### PR TITLE
Crud-Generator without Form helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,34 +20,9 @@ Laravel CRUD Generator
         Appzcoder\CrudGenerator\CrudGeneratorServiceProvider::class,
     ],
     ```
-3. Install **laravelcollective/html** package for form & html.
-    * Run
+3. Run **composer update**
 
-    ```
-    composer require laravelcollective/html
-    // For laravel 5.1
-    composer require laravelcollective/html "5.1.*"
-    ```
-    
-    * Add service provider & aliases to **/config/app.php** file.
-    ```php
-    'providers' => [
-        ...
-
-        Collective\Html\HtmlServiceProvider::class,
-    ],
-
-    // Use the lines below for "laravelcollective/html" package otherwise remove it.
-    'aliases' => [
-        ...
-
-        'Form'      => Collective\Html\FormFacade::class,
-        'HTML'      => Collective\Html\HtmlFacade::class,
-    ],
-    ```    
-4. Run **composer update**
-
-5. Publish config file & generator template files.
+4. Publish config file & generator template files.
     ```
     php artisan vendor:publish
     ```

--- a/src/Commands/CrudCommand.php
+++ b/src/Commands/CrudCommand.php
@@ -78,7 +78,7 @@ class CrudCommand extends Command
             $requiredFieldsStr .= (isset($itemArray[2])
                 && (trim($itemArray[2]) == 'req'
                     || trim($itemArray[2]) == 'required'))
-            ? "'$currentField' => 'required', " : '';
+            ? 'required' : '';
         }
 
         $commaSeparetedString = implode("', '", $fillableArray);

--- a/src/Commands/CrudViewCommand.php
+++ b/src/Commands/CrudViewCommand.php
@@ -469,12 +469,12 @@ EOD;
             <<<EOD
             <div class="checkbox">
                 <label>
-                    <input type="radio" name="%1\$s" value="1" {{ old('%1\$s') && old('%1\$s') == 1 ? 'checked' : '' }} /> Yes
+                    <input type="radio" name="%1\$s" value="1" {{ old('%1\$s') && old('%1\$s') == '1' ? 'checked' : '' }} /> Yes
                 </label>
             </div>
             <div class="checkbox">
                 <label>
-                    <input type="radio" name="%1\$s" value="0"  {{ old('%1\$s') && old('%1\$s') == 0 ? 'checked' : '' }} /> No
+                    <input type="radio" name="%1\$s" value="0" {{ old('%1\$s') && old('%1\$s') == '0' ? 'checked' : '' }} /> No
                 </label>
             </div>
 EOD;

--- a/src/Commands/CrudViewCommand.php
+++ b/src/Commands/CrudViewCommand.php
@@ -397,7 +397,7 @@ EOD;
      */
     protected function createFormField($item)
     {
-        $required = ($item['required'] === true) ? ", 'required' => 'required'" : "";
+        $required = ($item['required'] === true) ? "required " : "";
 
         return $this->wrapField(
             $item,
@@ -414,7 +414,7 @@ EOD;
      */
     protected function createPasswordField($item)
     {
-        $required = ($item['required'] === true) ? ", 'required' => 'required'" : "";
+        $required = ($item['required'] === true) ? "required " : "";
 
         return $this->wrapField(
             $item,
@@ -431,7 +431,7 @@ EOD;
      */
     protected function createInputField($item)
     {
-        $required = ($item['required'] === true) ? ", 'required' => 'required'" : "";
+        $required = ($item['required'] === true) ? "required " : "";
 
         return $this->wrapField(
             $item,
@@ -448,7 +448,7 @@ EOD;
      */
     protected function createTextareaField($item)
     {
-        $required = ($item['required'] === true) ? ", 'required' => 'required'" : "";
+        $required = ($item['required'] === true) ? "required " : "";
 
         return $this->wrapField(
             $item,

--- a/src/Commands/CrudViewCommand.php
+++ b/src/Commands/CrudViewCommand.php
@@ -384,7 +384,7 @@ EOD;
                 return $this->createRadioField($item);
                 break;
             default: // text
-                return '$this->createFormField($item);'
+                return $this->createFormField($item);
         }
     }
 
@@ -446,7 +446,7 @@ EOD;
      *
      * @return string
      */
-    protected function createInputField($item)
+    protected function createTextareaField($item)
     {
         $required = ($item['required'] === true) ? ", 'required' => 'required'" : "";
 

--- a/src/Commands/CrudViewCommand.php
+++ b/src/Commands/CrudViewCommand.php
@@ -401,7 +401,7 @@ EOD;
 
         return $this->wrapField(
             $item,
-            "<input type=\"text\" class=\"form-control\" name=\"". $item['name'] ."\" $required/>"
+            "<input type=\"". $this->typeLookup[$item['type']] ."\" class=\"form-control\" name=\"". $item['name'] ."\" $required/>"
         );
     }
 

--- a/src/Commands/CrudViewCommand.php
+++ b/src/Commands/CrudViewCommand.php
@@ -378,7 +378,7 @@ EOD;
             case 'time':
                 return $this->createInputField($item);
                 break;
-            case 'textarea'
+            case 'textarea':
                 return $this->createTextareaField($item);
             case 'radio':
                 return $this->createRadioField($item);

--- a/src/Commands/CrudViewCommand.php
+++ b/src/Commands/CrudViewCommand.php
@@ -352,11 +352,9 @@ class CrudViewCommand extends Command
         $formGroup =
             <<<EOD
             <div class="form-group {{ \$errors->has('%1\$s') ? 'has-error' : ''}}">
-                {!! Form::label('%1\$s', '%2\$s: ', ['class' => 'col-sm-3 control-label']) !!}
-                <div class="col-sm-6">
+                <label for="%1\$s" class="control-label">%2\$s:</label>
                     %3\$s
                     {!! \$errors->first('%1\$s', '<p class="help-block">:message</p>') !!}
-                </div>
             </div>\n
 EOD;
 
@@ -378,6 +376,7 @@ EOD;
                 break;
             case 'datetime-local':
             case 'time':
+            case 'text'
                 return $this->createInputField($item);
                 break;
             case 'radio':
@@ -401,7 +400,7 @@ EOD;
 
         return $this->wrapField(
             $item,
-            "{!! Form::" . $this->typeLookup[$item['type']] . "('" . $item['name'] . "', null, ['class' => 'form-control'$required]) !!}"
+            "<input type='" . $this->typeLookup[$item['type']] . "' class='form-control' name='". $item['name'] ."' $required/>"
         );
     }
 
@@ -418,7 +417,7 @@ EOD;
 
         return $this->wrapField(
             $item,
-            "{!! Form::password('" . $item['name'] . "', ['class' => 'form-control'$required]) !!}"
+            "<input type='password' class='form-control' name='". $item['name'] ."' $required/>"
         );
     }
 
@@ -435,7 +434,7 @@ EOD;
 
         return $this->wrapField(
             $item,
-            "{!! Form::input('" . $this->typeLookup[$item['type']] . "', '" . $item['name'] . "', null, ['class' => 'form-control'$required]) !!}"
+            "<input type='". $this->typeLookup[$item['type']] ."' class='form-control' name='". $item['name'] ."' $required/>"
         );
     }
 
@@ -451,10 +450,14 @@ EOD;
         $field =
             <<<EOD
             <div class="checkbox">
-                <label>{!! Form::radio('%1\$s', '1') !!} Yes</label>
+                <label>
+                    <input type="radio" name="%1\$s" value="1"/> Yes
+                </label>
             </div>
             <div class="checkbox">
-                <label>{!! Form::radio('%1\$s', '0', true) !!} No</label>
+                <label>
+                    <input type="radio" name="%1\$s" value="0"/> No
+                </label>
             </div>
 EOD;
 

--- a/src/Commands/CrudViewCommand.php
+++ b/src/Commands/CrudViewCommand.php
@@ -401,7 +401,7 @@ EOD;
 
         return $this->wrapField(
             $item,
-            "<input type=\"". $this->typeLookup[$item['type']] ."\" class=\"form-control\" name=\"". $item['name'] ."\" $required/>"
+            "<input type=\"". $this->typeLookup[$item['type']] ."\" class=\"form-control\" name=\"". $item['name'] ."\" value=\"{{ old('". $item['name'] ."') ? old('". $item['name'] ."') : (isset($". $this->crudNameSingular ."->" . $item['name'] . ") ? $". $this->crudNameSingular ."->" . $item['name'] ." : '') }}\" $required/>"
         );
     }
 
@@ -435,7 +435,7 @@ EOD;
 
         return $this->wrapField(
             $item,
-            "<input type=\"". $this->typeLookup[$item['type']] ."\" class=\"form-control\" name=\"". $item['name'] ."\" $required/>"
+            "<input type=\"". $this->typeLookup[$item['type']] ."\" class=\"form-control\" name=\"". $item['name'] ."\" value=\"{{ old('". $item['name'] ."') ? old('". $item['name'] ."') : (isset($". $this->crudNameSingular ."->" . $item['name'] . ") ? $". $this->crudNameSingular ."->" . $item['name'] ." : '') }}\" $required/>"
         );
     }
 
@@ -452,7 +452,7 @@ EOD;
 
         return $this->wrapField(
             $item,
-            "<textarea class=\"form-control\" name=\"". $item['name'] ."\" $required></textarea>"
+            "<textarea class=\"form-control\" name=\"". $item['name'] ."\" $required>{{ old('". $item['name'] ."') ? old('". $item['name'] ."') : (isset($". $this->crudNameSingular ."->" . $item['name'] . ") ? $". $this->crudNameSingular ."->" . $item['name'] ." : '') }}</textarea>"
         );
     }
 
@@ -469,12 +469,12 @@ EOD;
             <<<EOD
             <div class="checkbox">
                 <label>
-                    <input type="radio" name="%1\$s" value="1"/> Yes
+                    <input type="radio" name="%1\$s" value="1" {{ old('%1\$s') && old('%1\$s') == 1 ? 'checked' : '' }} /> Yes
                 </label>
             </div>
             <div class="checkbox">
                 <label>
-                    <input type="radio" name="%1\$s" value="0"/> No
+                    <input type="radio" name="%1\$s" value="0"  {{ old('%1\$s') && old('%1\$s') == 0 ? 'checked' : '' }} /> No
                 </label>
             </div>
 EOD;

--- a/src/Commands/CrudViewCommand.php
+++ b/src/Commands/CrudViewCommand.php
@@ -376,14 +376,15 @@ EOD;
                 break;
             case 'datetime-local':
             case 'time':
-            case 'text'
                 return $this->createInputField($item);
                 break;
+            case 'textarea'
+                return $this->createTextareaField($item);
             case 'radio':
                 return $this->createRadioField($item);
                 break;
             default: // text
-                return $this->createFormField($item);
+                return '$this->createFormField($item);'
         }
     }
 
@@ -400,7 +401,7 @@ EOD;
 
         return $this->wrapField(
             $item,
-            "<input type='" . $this->typeLookup[$item['type']] . "' class='form-control' name='". $item['name'] ."' $required/>"
+            "<input type=\"text\" class=\"form-control\" name=\"". $item['name'] ."\" $required/>"
         );
     }
 
@@ -417,7 +418,7 @@ EOD;
 
         return $this->wrapField(
             $item,
-            "<input type='password' class='form-control' name='". $item['name'] ."' $required/>"
+            "<input type=\"password\" class=\"form-control\" name=\"". $item['name'] ."\" $required/>"
         );
     }
 
@@ -434,7 +435,24 @@ EOD;
 
         return $this->wrapField(
             $item,
-            "<input type='". $this->typeLookup[$item['type']] ."' class='form-control' name='". $item['name'] ."' $required/>"
+            "<input type=\"". $this->typeLookup[$item['type']] ."\" class=\"form-control\" name=\"". $item['name'] ."\" $required/>"
+        );
+    }
+
+        /**
+     * Create a textarea field using the form helper.
+     *
+     * @param  string $item
+     *
+     * @return string
+     */
+    protected function createInputField($item)
+    {
+        $required = ($item['required'] === true) ? ", 'required' => 'required'" : "";
+
+        return $this->wrapField(
+            $item,
+            "<textarea class=\"form-control\" name=\"". $item['name'] ."\" $required></textarea>"
         );
     }
 

--- a/src/stubs/controller.stub
+++ b/src/stubs/controller.stub
@@ -38,6 +38,8 @@ class DummyClass extends Controller
     /**
      * Store a newly created resource in storage.
      *
+     * @param  Request  $request
+     *
      * @return Response
      */
     public function store(Request $request)
@@ -82,6 +84,7 @@ class DummyClass extends Controller
      * Update the specified resource in storage.
      *
      * @param  int  $id
+     * @param  Request  $request
      *
      * @return Response
      */

--- a/src/stubs/create.blade.stub
+++ b/src/stubs/create.blade.stub
@@ -5,7 +5,7 @@
     <h1>Create New %%modelName%%</h1>
     <hr/>
 
-    <form method="post" action="%%routeGroup%%%%crudName%%">
+    <form method="post" action="/%%routeGroup%%%%crudName%%">
         {{ csrf_field() }}
         %%formFieldsHtml%%
 

--- a/src/stubs/create.blade.stub
+++ b/src/stubs/create.blade.stub
@@ -6,7 +6,7 @@
     <hr/>
 
     <form method="post" action="%%routeGroup%%%%crudName%%">
-   
+        {{ csrf_field() }}
         %%formFieldsHtml%%
 
         <div class="form-group">

--- a/src/stubs/create.blade.stub
+++ b/src/stubs/create.blade.stub
@@ -5,23 +5,15 @@
     <h1>Create New %%modelName%%</h1>
     <hr/>
 
-    {!! Form::open(['url' => '%%routeGroup%%%%crudName%%', 'class' => 'form-horizontal']) !!}
-
-    %%formFieldsHtml%%
+    <form action="%%routeGroup%%%%crudName%%">
+   
+        %%formFieldsHtml%%
 
     <div class="form-group">
-        <div class="col-sm-offset-3 col-sm-3">
-            {!! Form::submit('Create', ['class' => 'btn btn-primary form-control']) !!}
-        </div>
+        <button type="submit" class="btn btn-primary">Create</button>
     </div>
-    {!! Form::close() !!}
 
-    @if ($errors->any())
-        <ul class="alert alert-danger">
-            @foreach ($errors->all() as $error)
-                <li>{{ $error }}</li>
-            @endforeach
-        </ul>
-    @endif
+    </form>
+
 
 @endsection

--- a/src/stubs/create.blade.stub
+++ b/src/stubs/create.blade.stub
@@ -5,7 +5,7 @@
     <h1>Create New %%modelName%%</h1>
     <hr/>
 
-    <form action="%%routeGroup%%%%crudName%%">
+    <form method="post" action="%%routeGroup%%%%crudName%%">
    
         %%formFieldsHtml%%
 

--- a/src/stubs/create.blade.stub
+++ b/src/stubs/create.blade.stub
@@ -9,9 +9,9 @@
    
         %%formFieldsHtml%%
 
-    <div class="form-group">
-        <button type="submit" class="btn btn-primary">Create</button>
-    </div>
+        <div class="form-group">
+            <button type="submit" class="btn btn-primary">Create</button>
+        </div>
 
     </form>
 

--- a/src/stubs/edit.blade.stub
+++ b/src/stubs/edit.blade.stub
@@ -5,7 +5,7 @@
     <h1>Edit %%modelName%%</h1>
     <hr/>
 
-    <form method="post" action="/%%routeGroup%%%%crudName%%/%%crudName%%->id">
+    <form method="post" action="/%%routeGroup%%%%crudName%%/{{ %%crudName%%->id }}">
         {{ csrf_field() }}
         {{ method_field('PATCH') }}
 

--- a/src/stubs/edit.blade.stub
+++ b/src/stubs/edit.blade.stub
@@ -5,7 +5,7 @@
     <h1>Edit %%modelName%%</h1>
     <hr/>
 
-    <form method="post" action="/%%routeGroup%%%%crudName%%/{{ %%crudName%%->id }}">
+    <form method="post" action="/%%routeGroup%%%%crudName%%/{{ $%%crudName%%->id }}">
         {{ csrf_field() }}
         {{ method_field('PATCH') }}
 

--- a/src/stubs/edit.blade.stub
+++ b/src/stubs/edit.blade.stub
@@ -5,7 +5,7 @@
     <h1>Edit %%modelName%%</h1>
     <hr/>
 
-    <form method="post" action="%%routeGroup%%%%crudName%%">
+    <form method="post" action="/%%routeGroup%%%%crudName%%">
         {{ csrf_field() }}
         {{ method_field('PATCH') }}
 

--- a/src/stubs/edit.blade.stub
+++ b/src/stubs/edit.blade.stub
@@ -6,6 +6,7 @@
     <hr/>
 
     <form method="post" action="%%routeGroup%%%%crudName%%">
+        {{ csrf_field() }}
         {{ method_field('PATCH') }}
 
         %%formFieldsHtml%%

--- a/src/stubs/edit.blade.stub
+++ b/src/stubs/edit.blade.stub
@@ -5,7 +5,7 @@
     <h1>Edit %%modelName%%</h1>
     <hr/>
 
-    <form method="post" action="/%%routeGroup%%%%crudName%%">
+    <form method="post" action="/%%routeGroup%%%%crudName%%/%%crudName%%->id">
         {{ csrf_field() }}
         {{ method_field('PATCH') }}
 

--- a/src/stubs/edit.blade.stub
+++ b/src/stubs/edit.blade.stub
@@ -5,7 +5,7 @@
     <h1>Edit %%modelName%%</h1>
     <hr/>
 
-    <form method="post" action="/%%routeGroup%%%%crudName%%/{{ $%%crudName%%->id }}">
+    <form method="post" action="/%%routeGroup%%%%crudName%%/{{ $%%crudNameSingular%%->id }}">
         {{ csrf_field() }}
         {{ method_field('PATCH') }}
 

--- a/src/stubs/edit.blade.stub
+++ b/src/stubs/edit.blade.stub
@@ -5,20 +5,18 @@
     <h1>Edit %%modelName%%</h1>
     <hr/>
 
-    {!! Form::model($%%crudNameSingular%%, [
-        'method' => 'PATCH',
-        'url' => ['%%routeGroup%%%%crudName%%', $%%crudNameSingular%%->id],
-        'class' => 'form-horizontal'
-    ]) !!}
+    <form method="post" action="%%routeGroup%%%%crudName%%">
+        {{ method_field('PATCH') }}
 
-    %%formFieldsHtml%%
+        %%formFieldsHtml%%
 
-    <div class="form-group">
-        <div class="col-sm-offset-3 col-sm-3">
-            {!! Form::submit('Update', ['class' => 'btn btn-primary form-control']) !!}
+        <div class="form-group">
+            <div class="col-sm-offset-3 col-sm-3">
+                {!! Form::submit('Update', ['class' => 'btn btn-primary form-control']) !!}
+            </div>
         </div>
-    </div>
-    {!! Form::close() !!}
+
+    </form>
 
     @if ($errors->any())
         <ul class="alert alert-danger">

--- a/src/stubs/edit.blade.stub
+++ b/src/stubs/edit.blade.stub
@@ -12,19 +12,9 @@
         %%formFieldsHtml%%
 
         <div class="form-group">
-            <div class="col-sm-offset-3 col-sm-3">
-                {!! Form::submit('Update', ['class' => 'btn btn-primary form-control']) !!}
-            </div>
+            <button type="submit" class="btn btn-primary">Update</button>
         </div>
 
     </form>
-
-    @if ($errors->any())
-        <ul class="alert alert-danger">
-            @foreach ($errors->all() as $error)
-                <li>{{ $error }}</li>
-            @endforeach
-        </ul>
-    @endif
 
 @endsection

--- a/src/stubs/index.blade.stub
+++ b/src/stubs/index.blade.stub
@@ -32,7 +32,7 @@
             @endforeach
             </tbody>
         </table>
-        <div class="pagination"> {!! $%%crudName%%->render() !!} </div>
+        {{-- <div class="pagination"> {!! $%%crudName%%->render() !!} </div> --}}
     </div>
 
 @endsection

--- a/src/stubs/index.blade.stub
+++ b/src/stubs/index.blade.stub
@@ -32,7 +32,7 @@
             @endforeach
             </tbody>
         </table>
-        {{-- <div class="pagination"> {!! $%%crudName%%->render() !!} </div> --}}
+        <div class="pagination"> {!! $%%crudName%%->render() !!} </div>
     </div>
 
 @endsection

--- a/src/stubs/index.blade.stub
+++ b/src/stubs/index.blade.stub
@@ -18,14 +18,15 @@
                     <td>{{ $x }}</td>
                     %%formBodyHtml%%
                     <td>
-                        <a href="{{ url('%%routeGroup%%%%crudName%%/' . $item->id . '/edit') }}" class="btn btn-primary btn-xs">Update</a> 
-                        {!! Form::open([
-                            'method'=>'DELETE',
-                            'url' => ['%%routeGroup%%%%crudName%%', $item->id],
-                            'style' => 'display:inline'
-                        ]) !!}
-                            {!! Form::submit('Delete', ['class' => 'btn btn-danger btn-xs']) !!}
-                        {!! Form::close() !!}
+                        <a href="{{ url('%%routeGroup%%%%crudName%%/' . $item->id . '/edit') }}" class="btn btn-primary btn-xs">
+                            Update
+                        </a>
+                        <form method="post" action="/%%routeGroup%%%%crudName%%/{{ $item->id }}">
+                            {{ csrf_field() }}
+                            {{ method_field('DELETE') }}
+                            
+                            <button type="submit" class="btn btn-danger btn-xs">Delete</button>
+                        </form>
                     </td>
                 </tr>
             @endforeach

--- a/src/stubs/index.blade.stub
+++ b/src/stubs/index.blade.stub
@@ -32,7 +32,7 @@
             @endforeach
             </tbody>
         </table>
-        <div class="pagination"> {!! $%%crudName%%->appends(Request::except('page'))->render() !!} </div>
+        <div class="pagination"> {!! $%%crudName%%->render() !!} </div>
     </div>
 
 @endsection


### PR DESCRIPTION
I rewrote everything to be able to use this plugin without the form helper. All fields have been replaced by normal fields and I used old() and isset() on variables in the edit field to maintain the form-model binding functionality