### PR TITLE
Fix for multiword class names

### DIFF
--- a/src/Commands/CrudCommand.php
+++ b/src/Commands/CrudCommand.php
@@ -57,7 +57,7 @@ class CrudCommand extends Command
         $modelName = str_singular($name);
         $migrationName = str_plural(snake_case($name));
         $tableName = $migrationName;
-        $viewName = strtolower($name);
+        $viewName = snake_case($name);
 
         $routeGroup = $this->option('route-group');
         $this->routeName = ($routeGroup) ? $routeGroup . '/' . snake_case($name, '-') : snake_case($name, '-');

--- a/src/Commands/CrudCommand.php
+++ b/src/Commands/CrudCommand.php
@@ -55,12 +55,12 @@ class CrudCommand extends Command
     {
         $name = $this->argument('name');
         $modelName = str_singular($name);
-        $migrationName = str_plural(strtolower($name));
+        $migrationName = str_plural(snake_case($name));
         $tableName = $migrationName;
         $viewName = strtolower($name);
 
         $routeGroup = $this->option('route-group');
-        $this->routeName = ($routeGroup) ? $routeGroup . '/' . strtolower($name) : strtolower($name);
+        $this->routeName = ($routeGroup) ? $routeGroup . '/' . snake_case($name, '-') : snake_case($name, '-');
 
         $controllerNamespace = ($this->option('namespace')) ? $this->option('namespace') . '\\' : '';
 


### PR DESCRIPTION
Goal of this PR is to make table names, routes and views generated using multi-word name be more human readable and more consistent with base laravel generators.

For example when generating CRUD for MeetingDates model using `$ php artisan crud generate MeetingDates`:
1. The table name will be "meeteng_dates" instead of "meetingdates", just like laravel's `artisan make:model MeetingDates -m` would do it.
2. Route now looks "/meeting-dates" which is [recommended by Google format](https://support.google.com/webmasters/answer/76329?hl=en) and much more readable then "/meetingdates".
3. view folder name will also be "meeteng_dates" instead of "meetingdates" which also more readable.