### PR TITLE
Improvements to views

### DIFF
--- a/src/Commands/CrudViewCommand.php
+++ b/src/Commands/CrudViewCommand.php
@@ -143,6 +143,7 @@ class CrudViewCommand extends Command
      * @var string
      */
     protected $formBodyHtml = '';
+   
 
     /**
      * Html of view to show.
@@ -227,14 +228,9 @@ class CrudViewCommand extends Command
             if($this->option('localize') == 'yes') {
                 $label = 'trans(\'' . $this->crudName . '.' . $field . '\')';
             }
-            $this->formHeadingHtml .= '<th>{{ ' . $label . ' }}</th>';
-
-            if ($i == 0) {
-                $this->formBodyHtml .= '<td><a href="{{ url(\'%%routeGroup%%%%crudName%%\', $item->id) }}">{{ $item->' . $field . ' }}</a></td>';
-            } else {
-                $this->formBodyHtml .= '<td>{{ $item->' . $field . ' }}</td>';
-            }
-            $this->formBodyHtmlForShowView .= '<td> {{ $%%crudNameSingular%%->' . $field . ' }} </td>';
+            $this->formHeadingHtml .= '<th> ' . $label . ' </th>';
+            $this->formBodyHtml .= '<td>{{ $item->' . $field . ' }}</td>';
+            $this->formBodyHtmlForShowView .= '<tr><th> ' . $label . ' </th><td> {{ $%%crudNameSingular%%->' . $field . ' }} </td></tr>';
 
             $i++;
         }
@@ -341,11 +337,14 @@ class CrudViewCommand extends Command
     public function templateShowVars($newShowFile)
     {
         File::put($newShowFile, str_replace('%%formHeadingHtml%%', $this->formHeadingHtml, File::get($newShowFile)));
-        File::put($newShowFile, str_replace('%%formBodyHtml%%', $this->formBodyHtmlForShowView, File::get($newShowFile)));
+        File::put($newShowFile, str_replace('%%formBodyHtmlForShowView%%', $this->formBodyHtmlForShowView, File::get($newShowFile)));
         File::put($newShowFile, str_replace('%%crudNameSingular%%', $this->crudNameSingular, File::get($newShowFile)));
         File::put($newShowFile, str_replace('%%crudNameCap%%', $this->crudNameCap, File::get($newShowFile)));
         File::put($newShowFile, str_replace('%%modelName%%', $this->modelName, File::get($newShowFile)));
         File::put($newShowFile, str_replace('%%primaryKey%%', $this->primaryKey, File::get($newShowFile)));
+        File::put($newShowFile, str_replace('%%crudName%%', $this->crudName, File::get($newShowFile)));
+        File::put($newShowFile, str_replace('%%routeGroup%%', $this->routeGroup, File::get($newShowFile)));
+
     }
 
     /**

--- a/src/stubs/edit.blade.stub
+++ b/src/stubs/edit.blade.stub
@@ -3,8 +3,7 @@
 @section('content')
 <div class="container">
 
-    <h1>Edit %%modelName%%</h1>
-    <hr/>
+    <h1>Edit %%modelName%% {{ $%%crudNameSingular%%->%%primaryKey%% }}</h1>
 
     {!! Form::model($%%crudNameSingular%%, [
         'method' => 'PATCH',

--- a/src/stubs/index.blade.stub
+++ b/src/stubs/index.blade.stub
@@ -3,7 +3,7 @@
 @section('content')
 <div class="container">
 
-    <h1>%%crudNameCap%% <a href="{{ url('/%%routeGroup%%%%crudName%%/create') }}" class="btn btn-primary pull-right btn-sm">Add New %%modelName%%</a></h1>
+    <h1>%%crudNameCap%% <a href="{{ url('/%%routeGroup%%%%crudName%%/create') }}" class="btn btn-primary btn-xs"><span class="glyphicon glyphicon-plus" aria-hidden="true"/></a></h1>
     <div class="table">
         <table class="table table-bordered table-striped table-hover">
             <thead>
@@ -19,13 +19,18 @@
                     <td>{{ $x }}</td>
                     %%formBodyHtml%%
                     <td>
-                        <a href="{{ url('/%%routeGroup%%%%crudName%%/' . $item->%%primaryKey%% . '/edit') }}" class="btn btn-primary btn-xs">Update</a>
+                        <a href="{{ url('/%%routeGroup%%%%crudName%%/' . $item->%%primaryKey%%) }}" class="btn btn-success btn-xs"><span class="glyphicon glyphicon-eye-open" aria-hidden="true"/></a> 
+                        <a href="{{ url('/%%routeGroup%%%%crudName%%/' . $item->%%primaryKey%% . '/edit') }}" class="btn btn-primary btn-xs"><span class="glyphicon glyphicon-pencil" aria-hidden="true"/></a> 
                         {!! Form::open([
                             'method'=>'DELETE',
                             'url' => ['/%%routeGroup%%%%crudName%%', $item->%%primaryKey%%],
                             'style' => 'display:inline'
                         ]) !!}
-                            {!! Form::submit('Delete', ['class' => 'btn btn-danger btn-xs']) !!}
+                            {!! Form::button('<span class="glyphicon glyphicon-trash" aria-hidden="true"/>', array(
+                                    'type' => 'submit',
+                                    'class'=> 'btn btn-danger btn-xs',
+                                    'onclick'=>'return confirm("Confirm delete?")'
+                            ));!!}
                         {!! Form::close() !!}
                     </td>
                 </tr>

--- a/src/stubs/show.blade.stub
+++ b/src/stubs/show.blade.stub
@@ -3,19 +3,33 @@
 @section('content')
 <div class="container">
 
-    <h1>%%modelName%%</h1>
+    <h1>%%modelName%% {{ $%%crudNameSingular%%->%%primaryKey%% }}</h1>
     <div class="table-responsive">
         <table class="table table-bordered table-striped table-hover">
-            <thead>
-                <tr>
-                    <th>ID.</th> %%formHeadingHtml%%
-                </tr>
-            </thead>
             <tbody>
                 <tr>
-                    <td>{{ $%%crudNameSingular%%->%%primaryKey%% }}</td> %%formBodyHtml%%
+                    <th>ID.</th><td>{{ $%%crudNameSingular%%->%%primaryKey%% }}</td>
                 </tr>
+                %%formBodyHtmlForShowView%%
             </tbody>
+            <tfoot>
+                <tr>
+                    <td colspan="2">
+                        <a href="{{ url('%%routeGroup%%%%crudName%%/' . $%%crudNameSingular%%->id . '/edit') }}" class="btn btn-primary btn-xs"><span class="glyphicon glyphicon-pencil" aria-hidden="true"/></a> 
+                        {!! Form::open([
+                            'method'=>'DELETE',
+                            'url' => ['%%routeGroup%%%%crudName%%', $%%crudNameSingular%%->id],
+                            'style' => 'display:inline'
+                        ]) !!}
+                            {!! Form::button('<span class="glyphicon glyphicon-trash" aria-hidden="true"/>', array(
+                                    'type' => 'submit',
+                                    'class'=> 'btn btn-danger btn-xs',
+                                    'onclick'=>'return confirm("Confirm delete?")'
+                            ));!!}
+                        {!! Form::close() !!}
+                    </td>
+                </tr>
+            </tfoot>
         </table>
     </div>
 


### PR DESCRIPTION
- Replaced words for icons.
- Put primary key on title for show and edit views because otherwise title is not specific to current item
- Index views had a link on the first column to go to the show view, this is replaced by an "eye" icon on the actions column
- Show view now is a "DetailView" vertical, useful when showing a lot of columns, not available in list view, also useful for text colums