### PR TITLE
Change pagination class of pagination div

### DIFF
--- a/src/stubs/index.blade.stub
+++ b/src/stubs/index.blade.stub
@@ -38,7 +38,7 @@
             @endforeach
             </tbody>
         </table>
-        <div class="pagination"> {!! $%%crudName%%->render() !!} </div>
+        <div class="pagination-wrapper"> {!! $%%crudName%%->render() !!} </div>
     </div>
 
 </div>


### PR DESCRIPTION
The div should not have the 'pagination' class. The render() method renders an unordered list with the pagination class.