### PR TITLE
adding lots of new options!

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ Options:
 - --pagination=25 : The amount of models per page for index pages.
 - --indexes : The fields to add an index to. append "#unique" to a field name to add a unique index
 - --foreign-keys= : Any foreign keys for the table. e.g. --foreign-keys="owner_id#id#owners" where owner_id is the column name, id is the name of the field on the foreign table, and owners is the name of the foreign table
+- --form-validation= : Validation for html form "my_col_name#validationRulesAsUsedInValidateFunction" e.g. "title#min:10|max:30|required" - See https://laravel.com/docs/master/validation#available-validation-rules
 - --relationships= : The relationships for the model. e.g. --relationships="comments#hasMany#App\Comment" in the format "relationshipname#type#args|SeparatedBy|Pipes"
-- --required-fields= : Required fields. These fields will be set to not null, and also receive a required in the forms
+- --required-fields= : Required fields for the table. These fields will be set to not null, and other fields will be nullable. Note, required will not be set on form fields, you must define that manually 
 - --localize=no : Localize the generated files? yes|no. 
 - --locales=en : Locales to create lang files for.
 

--- a/README.md
+++ b/README.md
@@ -78,8 +78,16 @@ Options:
 - --route : Include Crud route to routes.php? yes or no.
 - --pk : The name of the primary key.
 - --view-path : The name of the view path.
-- --namespace : Namespace of the controller.
+- --model-namespace : The namespace that the model will be placed in - directories will be created
+- --controller-namespace : The namespace of the controller - sub directories will be created
 - --route-group : Prefix of the route group.
+- --pagination=25 : The amount of models per page for index pages.
+- --indexes : The fields to add an index to. append "#unique" to a field name to add a unique index
+- --foreign-keys= : Any foreign keys for the table. e.g. --foreign-keys="owner_id#id#owners" where owner_id is the column name, id is the name of the field on the foreign table, and owners is the name of the foreign table
+- --relationships= : The relationships for the model. e.g. --relationships="comments#hasMany#App\Comment" in the format "relationshipname#type#args|SeparatedBy|Pipes"
+- --required-fields= : Required fields. These fields will be set to not null, and also receive a required in the forms
+- --localize=no : Localize the generated files? yes|no. 
+- --locales=en : Locales to create lang files for.
 
 -----------
 -----------
@@ -191,6 +199,6 @@ You can customize the generator's stub files/templates to achieve your need.
     ```
 3. From the directory **/resources/crud-generator/** you can modify or customize the stub files.
 
-##Author
+##Original Author
 
 [Sohel Amin](http://www.sohelamin.com)

--- a/src/Commands/CrudCommand.php
+++ b/src/Commands/CrudCommand.php
@@ -22,6 +22,7 @@ class CrudCommand extends Command
                             {--route-group= : Prefix of the route group.}
                             {--pagination= : The amount of models per page for index pages.}
                             {--indexes= : The fields to add an index to.}
+                            {--required-fields= : Required fields}
                             {--localize=no : Localize the generated files? yes|no. }
                             {--locales=en : Locales to create lang files for.}';
 
@@ -71,32 +72,26 @@ class CrudCommand extends Command
         $viewPath = $this->option('view-path');
 
         $fieldsArray = explode(',', $fields);
-        $requiredFieldsStr = '';
         $fillableArray = [];
 
         foreach ($fieldsArray as $item) {
             $spareParts = explode('#', trim($item));
             $fillableArray[] = $spareParts[0];
-
-            $currentField = trim($spareParts[0]);
-            $requiredFieldsStr .= (isset($spareParts[2]))
-            ? "'$currentField' => '{$spareParts[2]}', " : '';
         }
 
         $commaSeparetedString = implode("', '", $fillableArray);
         $fillable = "['" . $commaSeparetedString . "']";
 
-        $requiredFields = ($requiredFieldsStr != '') ? "[" . $requiredFieldsStr . "]" : '';
-
         $localize = $this->option('localize');
         $locales = $this->option('locales');
 
         $indexes = $this->option('indexes');
+        $required = $this->option('required-fields');
 
-        $this->call('crud:controller', ['name' => $controllerNamespace . $name . 'Controller', '--crud-name' => $name, '--model-name' => $modelName, '--view-path' => $viewPath, '--required-fields' => $requiredFields, '--route-group' => $routeGroup, '--pagination' => $perPage]);
+        $this->call('crud:controller', ['name' => $controllerNamespace . $name . 'Controller', '--crud-name' => $name, '--model-name' => $modelName, '--view-path' => $viewPath, '--required-fields' => $required, '--route-group' => $routeGroup, '--pagination' => $perPage]);
         $this->call('crud:model', ['name' => $modelName, '--fillable' => $fillable, '--table' => $tableName, '--pk' => $primaryKey]);
-        $this->call('crud:migration', ['name' => $migrationName, '--schema' => $fields, '--pk' => $primaryKey, '--indexes' => $indexes]);
-        $this->call('crud:view', ['name' => $name, '--fields' => $fields, '--view-path' => $viewPath, '--route-group' => $routeGroup, '--localize' => $localize, '--pk' => $primaryKey]);
+        $this->call('crud:migration', ['name' => $migrationName, '--schema' => $fields, '--pk' => $primaryKey, '--indexes' => $indexes, '--required-fields' => $required]);
+        $this->call('crud:view', ['name' => $name, '--fields' => $fields, '--view-path' => $viewPath, '--route-group' => $routeGroup, '--localize' => $localize, '--pk' => $primaryKey, '--required-fields' => $required]);
         if ($localize == 'yes') {
             $this->call('crud:lang', ['name' => $name, '--fields' => $fields, '--locales' => $locales]);
         }

--- a/src/Commands/CrudCommand.php
+++ b/src/Commands/CrudCommand.php
@@ -21,6 +21,7 @@ class CrudCommand extends Command
                             {--namespace= : Namespace of the controller.}
                             {--route-group= : Prefix of the route group.}
                             {--pagination= : The amount of models per page for index pages.}
+                            {--indexes= : The fields to add an index to.}
                             {--localize=no : Localize the generated files? yes|no. }
                             {--locales=en : Locales to create lang files for.}';
 
@@ -90,9 +91,11 @@ class CrudCommand extends Command
         $localize = $this->option('localize');
         $locales = $this->option('locales');
 
+        $indexes = $this->option('indexes');
+
         $this->call('crud:controller', ['name' => $controllerNamespace . $name . 'Controller', '--crud-name' => $name, '--model-name' => $modelName, '--view-path' => $viewPath, '--required-fields' => $requiredFields, '--route-group' => $routeGroup, '--pagination' => $perPage]);
         $this->call('crud:model', ['name' => $modelName, '--fillable' => $fillable, '--table' => $tableName, '--pk' => $primaryKey]);
-        $this->call('crud:migration', ['name' => $migrationName, '--schema' => $fields, '--pk' => $primaryKey]);
+        $this->call('crud:migration', ['name' => $migrationName, '--schema' => $fields, '--pk' => $primaryKey, '--indexes' => $indexes]);
         $this->call('crud:view', ['name' => $name, '--fields' => $fields, '--view-path' => $viewPath, '--route-group' => $routeGroup, '--localize' => $localize, '--pk' => $primaryKey]);
         if ($localize == 'yes') {
             $this->call('crud:lang', ['name' => $name, '--fields' => $fields, '--locales' => $locales]);

--- a/src/Commands/CrudCommand.php
+++ b/src/Commands/CrudCommand.php
@@ -22,7 +22,8 @@ class CrudCommand extends Command
                             {--route-group= : Prefix of the route group.}
                             {--pagination= : The amount of models per page for index pages.}
                             {--indexes= : The fields to add an index to.}
-                            {--foreign-keys= : Any foreign keys for the table}
+                            {--foreign-keys= : Any foreign keys for the table.}
+                            {--relationships= : The relationships for the model}
                             {--required-fields= : Required fields}
                             {--localize=no : Localize the generated files? yes|no. }
                             {--locales=en : Locales to create lang files for.}';
@@ -90,9 +91,10 @@ class CrudCommand extends Command
 
         $indexes = $this->option('indexes');
         $required = $this->option('required-fields');
+        $relationships = $this->option('relationships');
 
         $this->call('crud:controller', ['name' => $controllerNamespace . $name . 'Controller', '--crud-name' => $name, '--model-name' => $modelName, '--view-path' => $viewPath, '--required-fields' => $required, '--route-group' => $routeGroup, '--pagination' => $perPage]);
-        $this->call('crud:model', ['name' => $modelName, '--fillable' => $fillable, '--table' => $tableName, '--pk' => $primaryKey]);
+        $this->call('crud:model', ['name' => $modelName, '--fillable' => $fillable, '--table' => $tableName, '--pk' => $primaryKey, '--relationships' => $relationships]);
         $this->call('crud:migration', ['name' => $migrationName, '--schema' => $fields, '--pk' => $primaryKey, '--indexes' => $indexes, '--required-fields' => $required, '--foreign-keys' => $foreignKeys]);
         $this->call('crud:view', ['name' => $name, '--fields' => $fields, '--view-path' => $viewPath, '--route-group' => $routeGroup, '--localize' => $localize, '--pk' => $primaryKey, '--required-fields' => $required]);
         if ($localize == 'yes') {

--- a/src/Commands/CrudCommand.php
+++ b/src/Commands/CrudCommand.php
@@ -26,6 +26,7 @@ class CrudCommand extends Command
                             {--foreign-keys= : Any foreign keys for the table.}
                             {--relationships= : The relationships for the model}
                             {--required-fields= : Required fields}
+                            {--form-validation= : Validation details for the form fields}
                             {--localize=no : Localize the generated files? yes|no. }
                             {--locales=en : Locales to create lang files for.}';
 
@@ -91,12 +92,13 @@ class CrudCommand extends Command
         $localize = $this->option('localize');
         $locales = $this->option('locales');
 
-
         $indexes = $this->option('indexes');
         $required = $this->option('required-fields');
         $relationships = $this->option('relationships');
 
-        $this->call('crud:controller', ['name' => $controllerNamespace . $name . 'Controller', '--crud-name' => $name, '--model-name' => $modelName, '--view-path' => $viewPath, '--required-fields' => $required, '--route-group' => $routeGroup, '--pagination' => $perPage]);
+        $formValidation = trim($this->option('form-validation'));
+
+        $this->call('crud:controller', ['name' => $controllerNamespace . $name . 'Controller', '--crud-name' => $name, '--model-name' => $modelName, '--view-path' => $viewPath, '--required-fields' => $required, '--route-group' => $routeGroup, '--pagination' => $perPage, '--form-validation' => $formValidation]);
         $this->call('crud:model', ['name' => $modelNamespace . $modelName, '--fillable' => $fillable, '--table' => $tableName, '--pk' => $primaryKey, '--relationships' => $relationships]);
         $this->call('crud:migration', ['name' => $migrationName, '--schema' => $fields, '--pk' => $primaryKey, '--indexes' => $indexes, '--required-fields' => $required, '--foreign-keys' => $foreignKeys]);
         $this->call('crud:view', ['name' => $name, '--fields' => $fields, '--view-path' => $viewPath, '--route-group' => $routeGroup, '--localize' => $localize, '--pk' => $primaryKey, '--required-fields' => $required]);

--- a/src/Commands/CrudCommand.php
+++ b/src/Commands/CrudCommand.php
@@ -22,6 +22,7 @@ class CrudCommand extends Command
                             {--route-group= : Prefix of the route group.}
                             {--pagination= : The amount of models per page for index pages.}
                             {--indexes= : The fields to add an index to.}
+                            {--foreign-keys= : Any foreign keys for the table}
                             {--required-fields= : Required fields}
                             {--localize=no : Localize the generated files? yes|no. }
                             {--locales=en : Locales to create lang files for.}';
@@ -71,6 +72,8 @@ class CrudCommand extends Command
         $primaryKey = $this->option('pk');
         $viewPath = $this->option('view-path');
 
+        $foreignKeys = $this->option('foreign-keys');
+
         $fieldsArray = explode(',', $fields);
         $fillableArray = [];
 
@@ -90,7 +93,7 @@ class CrudCommand extends Command
 
         $this->call('crud:controller', ['name' => $controllerNamespace . $name . 'Controller', '--crud-name' => $name, '--model-name' => $modelName, '--view-path' => $viewPath, '--required-fields' => $required, '--route-group' => $routeGroup, '--pagination' => $perPage]);
         $this->call('crud:model', ['name' => $modelName, '--fillable' => $fillable, '--table' => $tableName, '--pk' => $primaryKey]);
-        $this->call('crud:migration', ['name' => $migrationName, '--schema' => $fields, '--pk' => $primaryKey, '--indexes' => $indexes, '--required-fields' => $required]);
+        $this->call('crud:migration', ['name' => $migrationName, '--schema' => $fields, '--pk' => $primaryKey, '--indexes' => $indexes, '--required-fields' => $required, '--foreign-keys' => $foreignKeys]);
         $this->call('crud:view', ['name' => $name, '--fields' => $fields, '--view-path' => $viewPath, '--route-group' => $routeGroup, '--localize' => $localize, '--pk' => $primaryKey, '--required-fields' => $required]);
         if ($localize == 'yes') {
             $this->call('crud:lang', ['name' => $name, '--fields' => $fields, '--locales' => $locales]);

--- a/src/Commands/CrudCommand.php
+++ b/src/Commands/CrudCommand.php
@@ -20,6 +20,7 @@ class CrudCommand extends Command
                             {--view-path= : The name of the view path.}
                             {--namespace= : Namespace of the controller.}
                             {--route-group= : Prefix of the route group.}
+                            {--pagination= : The amount of models per page for index pages.}
                             {--localize=no : Localize the generated files? yes|no. }
                             {--locales=en : Locales to create lang files for.}';
 
@@ -60,6 +61,7 @@ class CrudCommand extends Command
 
         $routeGroup = $this->option('route-group');
         $this->routeName = ($routeGroup) ? $routeGroup . '/' . snake_case($name, '-') : snake_case($name, '-');
+        $perPage = $this->option('pagination') ? intval($this->option('pagination')) : 15;
 
         $controllerNamespace = ($this->option('namespace')) ? $this->option('namespace') . '\\' : '';
 
@@ -88,7 +90,7 @@ class CrudCommand extends Command
         $localize = $this->option('localize');
         $locales = $this->option('locales');
 
-        $this->call('crud:controller', ['name' => $controllerNamespace . $name . 'Controller', '--crud-name' => $name, '--model-name' => $modelName, '--view-path' => $viewPath, '--required-fields' => $requiredFields, '--route-group' => $routeGroup]);
+        $this->call('crud:controller', ['name' => $controllerNamespace . $name . 'Controller', '--crud-name' => $name, '--model-name' => $modelName, '--view-path' => $viewPath, '--required-fields' => $requiredFields, '--route-group' => $routeGroup, '--pagination' => $perPage]);
         $this->call('crud:model', ['name' => $modelName, '--fillable' => $fillable, '--table' => $tableName, '--pk' => $primaryKey]);
         $this->call('crud:migration', ['name' => $migrationName, '--schema' => $fields, '--pk' => $primaryKey]);
         $this->call('crud:view', ['name' => $name, '--fields' => $fields, '--view-path' => $viewPath, '--route-group' => $routeGroup, '--localize' => $localize, '--pk' => $primaryKey]);

--- a/src/Commands/CrudCommand.php
+++ b/src/Commands/CrudCommand.php
@@ -20,7 +20,7 @@ class CrudCommand extends Command
                             {--view-path= : The name of the view path.}
                             {--namespace= : Namespace of the controller.}
                             {--route-group= : Prefix of the route group.}
-                            {--pagination=15 : The amount of models per page for index pages.}
+                            {--pagination=25 : The amount of models per page for index pages.}
                             {--indexes= : The fields to add an index to.}
                             {--foreign-keys= : Any foreign keys for the table.}
                             {--relationships= : The relationships for the model}

--- a/src/Commands/CrudCommand.php
+++ b/src/Commands/CrudCommand.php
@@ -20,7 +20,7 @@ class CrudCommand extends Command
                             {--view-path= : The name of the view path.}
                             {--namespace= : Namespace of the controller.}
                             {--route-group= : Prefix of the route group.}
-                            {--pagination= : The amount of models per page for index pages.}
+                            {--pagination=15 : The amount of models per page for index pages.}
                             {--indexes= : The fields to add an index to.}
                             {--foreign-keys= : Any foreign keys for the table.}
                             {--relationships= : The relationships for the model}
@@ -65,7 +65,7 @@ class CrudCommand extends Command
 
         $routeGroup = $this->option('route-group');
         $this->routeName = ($routeGroup) ? $routeGroup . '/' . snake_case($name, '-') : snake_case($name, '-');
-        $perPage = $this->option('pagination') ? intval($this->option('pagination')) : 15;
+        $perPage = intval($this->option('pagination'));
 
         $controllerNamespace = ($this->option('namespace')) ? $this->option('namespace') . '\\' : '';
 

--- a/src/Commands/CrudCommand.php
+++ b/src/Commands/CrudCommand.php
@@ -18,7 +18,8 @@ class CrudCommand extends Command
                             {--route=yes : Include Crud route to routes.php? yes|no.}
                             {--pk=id : The name of the primary key.}
                             {--view-path= : The name of the view path.}
-                            {--namespace= : Namespace of the controller.}
+                            {--model-namespace= : Namespace of the model inside "app" dir}
+                            {--controller-namespace= : Namespace of the controller.}
                             {--route-group= : Prefix of the route group.}
                             {--pagination=25 : The amount of models per page for index pages.}
                             {--indexes= : The fields to add an index to.}
@@ -67,7 +68,8 @@ class CrudCommand extends Command
         $this->routeName = ($routeGroup) ? $routeGroup . '/' . snake_case($name, '-') : snake_case($name, '-');
         $perPage = intval($this->option('pagination'));
 
-        $controllerNamespace = ($this->option('namespace')) ? $this->option('namespace') . '\\' : '';
+        $controllerNamespace = ($this->option('controller-namespace')) ? $this->option('controller-namespace') . '\\' : '';
+        $modelNamespace = ($this->option('model-namespace')) ? trim($this->option('model-namespace')) . '\\' : '';
 
         $fields = $this->option('fields');
         $primaryKey = $this->option('pk');
@@ -89,12 +91,13 @@ class CrudCommand extends Command
         $localize = $this->option('localize');
         $locales = $this->option('locales');
 
+
         $indexes = $this->option('indexes');
         $required = $this->option('required-fields');
         $relationships = $this->option('relationships');
 
         $this->call('crud:controller', ['name' => $controllerNamespace . $name . 'Controller', '--crud-name' => $name, '--model-name' => $modelName, '--view-path' => $viewPath, '--required-fields' => $required, '--route-group' => $routeGroup, '--pagination' => $perPage]);
-        $this->call('crud:model', ['name' => $modelName, '--fillable' => $fillable, '--table' => $tableName, '--pk' => $primaryKey, '--relationships' => $relationships]);
+        $this->call('crud:model', ['name' => $modelNamespace . $modelName, '--fillable' => $fillable, '--table' => $tableName, '--pk' => $primaryKey, '--relationships' => $relationships]);
         $this->call('crud:migration', ['name' => $migrationName, '--schema' => $fields, '--pk' => $primaryKey, '--indexes' => $indexes, '--required-fields' => $required, '--foreign-keys' => $foreignKeys]);
         $this->call('crud:view', ['name' => $name, '--fields' => $fields, '--view-path' => $viewPath, '--route-group' => $routeGroup, '--localize' => $localize, '--pk' => $primaryKey, '--required-fields' => $required]);
         if ($localize == 'yes') {

--- a/src/Commands/CrudControllerCommand.php
+++ b/src/Commands/CrudControllerCommand.php
@@ -18,7 +18,7 @@ class CrudControllerCommand extends GeneratorCommand
                             {--view-path= : The name of the view path.}
                             {--required-fields= : Required fields for validations.}
                             {--route-group= : Prefix of the route group.}
-                            {--pagination=15 : The amount of models per page for index pages.}';
+                            {--pagination=25 : The amount of models per page for index pages.}';
 
     /**
      * The console command description.

--- a/src/Commands/CrudControllerCommand.php
+++ b/src/Commands/CrudControllerCommand.php
@@ -78,8 +78,17 @@ class CrudControllerCommand extends GeneratorCommand
         $viewName = snake_case($this->option('crud-name'), '-');
 
         $validationRules = '';
-        if ($this->option('required-fields') != '') {
-            $validationRules = "\$this->validate(\$request, " . $this->option('required-fields') . ");\n";
+        if (trim($this->option('required-fields')) != '') {
+            $validationRules = "\$this->validate(\$request, [";
+
+            $requireds = explode(',', $this->option('required-fields'));
+            foreach ($requireds as $req)
+            {
+                $req = trim($req);
+                $validationRules .= "'" . $req . "',";
+            }
+            $validationRules = substr($validationRules, 0, -1); // lose the last comma
+            $validationRules .= ']);';
         }
 
         return $this->replaceNamespace($stub, $name)

--- a/src/Commands/CrudControllerCommand.php
+++ b/src/Commands/CrudControllerCommand.php
@@ -17,6 +17,7 @@ class CrudControllerCommand extends GeneratorCommand
                             {--model-name= : The name of the Model.}
                             {--view-path= : The name of the view path.}
                             {--required-fields= : Required fields for validations.}
+                            {--form-validation= : Form validation}
                             {--route-group= : Prefix of the route group.}
                             {--pagination=25 : The amount of models per page for index pages.}';
 
@@ -76,19 +77,33 @@ class CrudControllerCommand extends GeneratorCommand
         $routeGroup = ($this->option('route-group')) ? $this->option('route-group') . '/' : '';
         $perPage = intval($this->option('pagination'));
         $viewName = snake_case($this->option('crud-name'), '-');
+        $validation = $this->option('form-validation');
 
         $validationRules = '';
-        if (trim($this->option('required-fields')) != '') {
+        if (trim($this->option('form-validation')) != '') {
             $validationRules = "\$this->validate(\$request, [";
 
-            $requireds = explode(',', $this->option('required-fields'));
-            foreach ($requireds as $req)
+            $rules = explode(',', $validation);
+            foreach ($rules as $v)
             {
-                $req = trim($req);
-                $validationRules .= "['" . $req . "' => 'required'],";
+                if (trim($v) == '')
+                    continue;
+
+                // extract field name and args
+                $parts = explode('#', $v);
+                $fieldName = trim($parts[0]);
+                $args = trim($parts[1]);
+                $validationRules .= "\n\t\t\t'$fieldName' => '$args',";
             }
+
+//            $requireds = explode(',', $this->option('required-fields'));
+//            foreach ($requireds as $req)
+//            {
+//                $req = trim($req);
+//                $validationRules .= "['" . $req . "' => 'required'],";
+//            }
             $validationRules = substr($validationRules, 0, -1); // lose the last comma
-            $validationRules .= ']);';
+            $validationRules .= "\n\t\t]);";
         }
 
         return $this->replaceNamespace($stub, $name)

--- a/src/Commands/CrudControllerCommand.php
+++ b/src/Commands/CrudControllerCommand.php
@@ -85,7 +85,7 @@ class CrudControllerCommand extends GeneratorCommand
             foreach ($requireds as $req)
             {
                 $req = trim($req);
-                $validationRules .= "'" . $req . "',";
+                $validationRules .= "['" . $req . "' => 'required'],";
             }
             $validationRules = substr($validationRules, 0, -1); // lose the last comma
             $validationRules .= ']);';

--- a/src/Commands/CrudControllerCommand.php
+++ b/src/Commands/CrudControllerCommand.php
@@ -17,7 +17,8 @@ class CrudControllerCommand extends GeneratorCommand
                             {--model-name= : The name of the Model.}
                             {--view-path= : The name of the view path.}
                             {--required-fields= : Required fields for validations.}
-                            {--route-group= : Prefix of the route group.}';
+                            {--route-group= : Prefix of the route group.}
+                            {--pagination= : The amount of models per page for index pages.}';
 
     /**
      * The console command description.
@@ -73,6 +74,7 @@ class CrudControllerCommand extends GeneratorCommand
         $crudNameSingular = str_singular($crudName);
         $modelName = $this->option('model-name');
         $routeGroup = ($this->option('route-group')) ? $this->option('route-group') . '/' : '';
+        $perPage = $this->option('pagination') ? intval($this->option('pagination')) : 15;
         $viewName = snake_case($this->option('crud-name'), '-');
 
         $validationRules = '';
@@ -88,6 +90,7 @@ class CrudControllerCommand extends GeneratorCommand
             ->replaceModelName($stub, $modelName)
             ->replaceRouteGroup($stub, $routeGroup)
             ->replaceValidationRules($stub, $validationRules)
+            ->replacePaginationNumber($stub, $perPage)
             ->replaceClass($stub, $name);
     }
 
@@ -205,6 +208,23 @@ class CrudControllerCommand extends GeneratorCommand
     {
         $stub = str_replace(
             '{{validationRules}}', $validationRules, $stub
+        );
+
+        return $this;
+    }
+
+    /**
+     * Replace the pagination placeholder for the given stub
+     *
+     * @param $stub
+     * @param $perPage
+     *
+     * @return $this
+     */
+    protected function replacePaginationNumber(&$stub, $perPage)
+    {
+        $stub = str_replace(
+            '{{pagination}}', $perPage, $stub
         );
 
         return $this;

--- a/src/Commands/CrudControllerCommand.php
+++ b/src/Commands/CrudControllerCommand.php
@@ -18,7 +18,7 @@ class CrudControllerCommand extends GeneratorCommand
                             {--view-path= : The name of the view path.}
                             {--required-fields= : Required fields for validations.}
                             {--route-group= : Prefix of the route group.}
-                            {--pagination= : The amount of models per page for index pages.}';
+                            {--pagination=15 : The amount of models per page for index pages.}';
 
     /**
      * The console command description.
@@ -74,7 +74,7 @@ class CrudControllerCommand extends GeneratorCommand
         $crudNameSingular = str_singular($crudName);
         $modelName = $this->option('model-name');
         $routeGroup = ($this->option('route-group')) ? $this->option('route-group') . '/' : '';
-        $perPage = $this->option('pagination') ? intval($this->option('pagination')) : 15;
+        $perPage = intval($this->option('pagination'));
         $viewName = snake_case($this->option('crud-name'), '-');
 
         $validationRules = '';

--- a/src/Commands/CrudMigrationCommand.php
+++ b/src/Commands/CrudMigrationCommand.php
@@ -14,6 +14,7 @@ class CrudMigrationCommand extends GeneratorCommand
     protected $signature = 'crud:migration
                             {name : The name of the migration.}
                             {--schema= : The name of the schema.}
+                            {--indexes= : The fields to add an index too}
                             {--pk=id : The name of the primary key.}';
 
     /**
@@ -71,6 +72,8 @@ class CrudMigrationCommand extends GeneratorCommand
         $tableName = $this->argument('name');
         $className = 'Create' . str_replace(' ', '', ucwords(str_replace('_', ' ', $tableName))) . 'Table';
 
+        $fieldsToIndex = explode(',', $this->option('indexes'));
+
         $schema = $this->option('schema');
         $fields = explode(',', $schema);
 
@@ -92,94 +95,101 @@ class CrudMigrationCommand extends GeneratorCommand
         foreach ($data as $item) {
             switch ($item['type']) {
                 case 'char':
-                    $schemaFields .= "\$table->char('" . $item['name'] . "');\n" . $tabIndent . $tabIndent . $tabIndent;
+                    $schemaFields .= "\$table->char('" . $item['name'] . "')";
                     break;
 
                 case 'date':
-                    $schemaFields .= "\$table->date('" . $item['name'] . "');\n" . $tabIndent . $tabIndent . $tabIndent;
+                    $schemaFields .= "\$table->date('" . $item['name'] . "')";
                     break;
 
                 case 'datetime':
-                    $schemaFields .= "\$table->dateTime('" . $item['name'] . "');\n" . $tabIndent . $tabIndent . $tabIndent;
+                    $schemaFields .= "\$table->dateTime('" . $item['name'] . "')";
                     break;
 
                 case 'time':
-                    $schemaFields .= "\$table->time('" . $item['name'] . "');\n" . $tabIndent . $tabIndent . $tabIndent;
+                    $schemaFields .= "\$table->time('" . $item['name'] . "')";
                     break;
 
                 case 'timestamp':
-                    $schemaFields .= "\$table->timestamp('" . $item['name'] . "');\n" . $tabIndent . $tabIndent . $tabIndent;
+                    $schemaFields .= "\$table->timestamp('" . $item['name'] . "')";
                     break;
 
                 case 'text':
-                    $schemaFields .= "\$table->text('" . $item['name'] . "');\n" . $tabIndent . $tabIndent . $tabIndent;
+                    $schemaFields .= "\$table->text('" . $item['name'] . "')";
                     break;
 
                 case 'mediumtext':
-                    $schemaFields .= "\$table->mediumText('" . $item['name'] . "');\n" . $tabIndent . $tabIndent . $tabIndent;
+                    $schemaFields .= "\$table->mediumText('" . $item['name'] . "')";
                     break;
 
                 case 'longtext':
-                    $schemaFields .= "\$table->longText('" . $item['name'] . "');\n" . $tabIndent . $tabIndent . $tabIndent;
+                    $schemaFields .= "\$table->longText('" . $item['name'] . "')";
                     break;
 
                 case 'json':
-                    $schemaFields .= "\$table->json('" . $item['name'] . "');\n" . $tabIndent . $tabIndent . $tabIndent;
+                    $schemaFields .= "\$table->json('" . $item['name'] . "')";
                     break;
 
                 case 'jsonb':
-                    $schemaFields .= "\$table->jsonb('" . $item['name'] . "');\n" . $tabIndent . $tabIndent . $tabIndent;
+                    $schemaFields .= "\$table->jsonb('" . $item['name'] . "')";
                     break;
 
                 case 'binary':
-                    $schemaFields .= "\$table->binary('" . $item['name'] . "');\n" . $tabIndent . $tabIndent . $tabIndent;
+                    $schemaFields .= "\$table->binary('" . $item['name'] . "')";
                     break;
 
                 case 'number':
                 case 'integer':
-                    $schemaFields .= "\$table->integer('" . $item['name'] . "');\n" . $tabIndent . $tabIndent . $tabIndent;
+                    $schemaFields .= "\$table->integer('" . $item['name'] . "')";
                     break;
 
                 case 'bigint':
-                    $schemaFields .= "\$table->bigInteger('" . $item['name'] . "');\n" . $tabIndent . $tabIndent . $tabIndent;
+                    $schemaFields .= "\$table->bigInteger('" . $item['name'] . "')";
                     break;
 
                 case 'mediumint':
-                    $schemaFields .= "\$table->mediumInteger('" . $item['name'] . "');\n" . $tabIndent . $tabIndent . $tabIndent;
+                    $schemaFields .= "\$table->mediumInteger('" . $item['name'] . "')";
                     break;
 
                 case 'tinyint':
-                    $schemaFields .= "\$table->tinyInteger('" . $item['name'] . "');\n" . $tabIndent . $tabIndent . $tabIndent;
+                    $schemaFields .= "\$table->tinyInteger('" . $item['name'] . "')";
                     break;
 
                 case 'smallint':
-                    $schemaFields .= "\$table->smallInteger('" . $item['name'] . "');\n" . $tabIndent . $tabIndent . $tabIndent;
+                    $schemaFields .= "\$table->smallInteger('" . $item['name'] . "')";
                     break;
 
                 case 'boolean':
-                    $schemaFields .= "\$table->boolean('" . $item['name'] . "');\n" . $tabIndent . $tabIndent . $tabIndent;
+                    $schemaFields .= "\$table->boolean('" . $item['name'] . "')";
                     break;
 
                 case 'decimal':
-                    $schemaFields .= "\$table->decimal('" . $item['name'] . "');\n" . $tabIndent . $tabIndent . $tabIndent;
+                    $schemaFields .= "\$table->decimal('" . $item['name'] . "')";
                     break;
 
                 case 'double':
-                    $schemaFields .= "\$table->double('" . $item['name'] . "');\n" . $tabIndent . $tabIndent . $tabIndent;
+                    $schemaFields .= "\$table->double('" . $item['name'] . "')";
                     break;
 
                 case 'float':
-                    $schemaFields .= "\$table->float('" . $item['name'] . "');\n" . $tabIndent . $tabIndent . $tabIndent;
+                    $schemaFields .= "\$table->float('" . $item['name'] . "')";
                     break;
 
                 case 'enum':
-                    $schemaFields .= "\$table->enum('" . $item['name'] . "', []);\n" . $tabIndent . $tabIndent . $tabIndent;
+                    $schemaFields .= "\$table->enum('" . $item['name'] . "', [])";
                     break;
 
                 default:
-                    $schemaFields .= "\$table->string('" . $item['name'] . "');\n" . $tabIndent . $tabIndent . $tabIndent;
+                    $schemaFields .= "\$table->string('" . $item['name'] . "')";
                     break;
             }
+
+            if (in_array($item['name'], $fieldsToIndex))
+            {
+                $schemaFields .= '->index()';
+            }
+
+            $schemaFields .= ";\n" . $tabIndent . $tabIndent . $tabIndent;
         }
 
         $primaryKey = $this->option('pk');

--- a/src/Commands/CrudMigrationCommand.php
+++ b/src/Commands/CrudMigrationCommand.php
@@ -16,6 +16,7 @@ class CrudMigrationCommand extends GeneratorCommand
                             {--schema= : The name of the schema.}
                             {--indexes= : The fields to add an index too}
                             {--required-fields= : Required fields}
+                            {--foreign-keys= : Foreign keys}
                             {--pk=id : The name of the primary key.}';
 
     /**
@@ -74,7 +75,8 @@ class CrudMigrationCommand extends GeneratorCommand
         $className = 'Create' . str_replace(' ', '', ucwords(str_replace('_', ' ', $tableName))) . 'Table';
 
         $fieldsToIndex = trim($this->option('indexes')) != '' ? explode(',', $this->option('indexes')) : [];
-        $fieldsToRequire = explode(',', $this->option('required-fields'));
+        $fieldsToRequire = trim($this->option('required-fields')) != '' ? explode(',', $this->option('required-fields')) : [];
+        $foreignKeys = trim($this->option('foreign-keys')) != '' ? explode(',', $this->option('foreign-keys')) : [];
 
         $schema = $this->option('schema');
         $fields = explode(',', $schema);
@@ -217,6 +219,26 @@ class CrudMigrationCommand extends GeneratorCommand
 
             $schemaFields .= ";\n" . $tabIndent . $tabIndent . $tabIndent;
         }
+
+        // foreign keys
+        foreach ($foreignKeys as $fk)
+        {
+            $line = trim($fk);
+
+            $parts = explode('#', $line);
+
+            // if we don't have three parts, then the foreign key isn't defined properly
+            // --foreign-keys="foreign_entity_id#id#foreign_entity"
+            if (count($parts) != 3)
+                continue;
+
+            $schemaFields .= "\$table->foreign('" . trim($parts[0]) . "')"
+                . "->references('" . trim($parts[1]) . "')->on('" . trim($parts[0]) . "')";
+
+            $schemaFields .= ";\n" . $tabIndent . $tabIndent . $tabIndent;
+
+        }
+
 
         $primaryKey = $this->option('pk');
 

--- a/src/Commands/CrudMigrationCommand.php
+++ b/src/Commands/CrudMigrationCommand.php
@@ -15,6 +15,7 @@ class CrudMigrationCommand extends GeneratorCommand
                             {name : The name of the migration.}
                             {--schema= : The name of the schema.}
                             {--indexes= : The fields to add an index too}
+                            {--required-fields= : Required fields}
                             {--pk=id : The name of the primary key.}';
 
     /**
@@ -73,6 +74,7 @@ class CrudMigrationCommand extends GeneratorCommand
         $className = 'Create' . str_replace(' ', '', ucwords(str_replace('_', ' ', $tableName))) . 'Table';
 
         $fieldsToIndex = explode(',', $this->option('indexes'));
+        $fieldsToRequire = explode(',', $this->option('required-fields'));
 
         $schema = $this->option('schema');
         $fields = explode(',', $schema);
@@ -187,6 +189,12 @@ class CrudMigrationCommand extends GeneratorCommand
             if (in_array($item['name'], $fieldsToIndex))
             {
                 $schemaFields .= '->index()';
+            }
+
+            // in the sql, laravel makes fields 'not null' by default, so we add nullable to fields that aren't required
+            if (!in_array($item['name'], $fieldsToRequire))
+            {
+                $schemaFields .= '->nullable()';
             }
 
             $schemaFields .= ";\n" . $tabIndent . $tabIndent . $tabIndent;

--- a/src/Commands/CrudModelCommand.php
+++ b/src/Commands/CrudModelCommand.php
@@ -15,6 +15,7 @@ class CrudModelCommand extends GeneratorCommand
                             {name : The name of the model.}
                             {--table= : The name of the table.}
                             {--fillable= : The names of the fillable columns.}
+                            {--relationships= : The relationships for the model}
                             {--pk=id : The name of the primary key.}';
 
     /**
@@ -68,6 +69,7 @@ class CrudModelCommand extends GeneratorCommand
         $table = $this->option('table') ?: $this->argument('name');
         $fillable = $this->option('fillable');
         $primaryKey = $this->option('pk');
+        $relationships = trim($this->option('relationships')) != '' ? explode(',', trim($this->option('relationships'))) : [];
 
         if(!empty($primaryKey)) {
             $primaryKey = <<<EOD
@@ -81,11 +83,40 @@ EOD;
 
         }
 
-        return $this->replaceNamespace($stub, $name)
+        $ret = $this->replaceNamespace($stub, $name)
             ->replaceTable($stub, $table)
             ->replaceFillable($stub, $fillable)
-            ->replacePrimaryKey($stub, $primaryKey)
-            ->replaceClass($stub, $name);
+            ->replacePrimaryKey($stub, $primaryKey);
+
+        foreach ($relationships as $rel)
+        {
+            // relationshipname#relationshiptype#args_separated_by_pipes
+            // e.g. employees#hasMany#App\Employee|id|dept_id
+            // user is responsible for ensuring these relationships are valid
+            $parts = explode('#',$rel);
+
+            if (count($parts) != 3)
+                continue;
+
+            // blindly wrap each arg in single quotes
+            $args = explode('|', trim($parts[2]));
+            $argsString = '';
+            foreach ($args as $k => $v)
+            {
+                if (trim($v) == '')
+                    continue;
+
+                $argsString .= "'" . trim($v) . "', ";
+            }
+
+            $argsString = substr($argsString, 0, -2);   // remove last comma
+
+            $ret->createRelationshipFunction($stub, trim($parts[0]), trim($parts[1]), $argsString);
+        }
+
+        $ret->replaceRelationshipPlaceholder($stub);
+
+        return $ret->replaceClass($stub, $name);
     }
 
     /**
@@ -136,6 +167,38 @@ EOD;
             '{{primaryKey}}', $primaryKey, $stub
         );
 
+        return $this;
+    }
+
+    /**
+     * Create the code for a model relationship
+     *
+     * @param string $stub
+     * @param string $relationshipName  the name of the function, e.g. owners
+     * @param string $relationshipType  the type of the relationship, hasOne, hasMany, belongsTo etc
+     * @param array $relationshipArgs   args for the relationship function
+     */
+    protected function createRelationshipFunction(&$stub, $relationshipName, $relationshipType, $argsString)
+    {
+        $code = "public function " . $relationshipName . "()\n\t{\n\t\t"
+            . "return \$this->" . $relationshipType . "(" . $argsString . ");"
+            . "\n\t}";
+
+        $str = '{{relationships}}';
+        $stub = str_replace($str, $code . "\n\t$str", $stub);
+
+        return $this;
+    }
+
+    /**
+     * remove the relationships placeholder when it's no longer needed
+     *
+     * @param $stub
+     * @return $this
+     */
+    protected function replaceRelationshipPlaceholder(&$stub)
+    {
+        $stub = str_replace('{{relationships}}', '', $stub);
         return $this;
     }
 }

--- a/src/Commands/CrudViewCommand.php
+++ b/src/Commands/CrudViewCommand.php
@@ -18,6 +18,7 @@ class CrudViewCommand extends Command
                             {--view-path= : The name of the view path.}
                             {--route-group= : Prefix of the route group.}
                             {--pk=id : The name of the primary key.}
+                            {--required-fields= : Required fields}
                             {--localize=no : Localize the view? yes|no.}';
 
     /**
@@ -74,6 +75,13 @@ class CrudViewCommand extends Command
      * @var array
      */
     protected $formFields = [];
+
+    /**
+     * Array of any required form fields
+     *
+     * @var array
+     */
+    protected $requiredFormFields = [];
 
     /**
      * Html of Form's fields.
@@ -209,13 +217,15 @@ class CrudViewCommand extends Command
 
         $this->formFields = array();
 
+        $this->requiredFormFields = explode(',', $this->option('required-fields'));
+
         if ($fields) {
             $x = 0;
             foreach ($fieldsArray as $item) {
                 $itemArray = explode('#', $item);
                 $this->formFields[$x]['name'] = trim($itemArray[0]);
                 $this->formFields[$x]['type'] = trim($itemArray[1]);
-                $this->formFields[$x]['required'] = (isset($itemArray[2]) && (trim($itemArray[2]) == 'req' || trim($itemArray[2]) == 'required')) ? true : false;
+                $this->formFields[$x]['required'] = in_array($itemArray[0], $this->requiredFormFields);
 
                 $x++;
             }

--- a/src/stubs/controller.stub
+++ b/src/stubs/controller.stub
@@ -19,7 +19,7 @@ class DummyClass extends Controller
      */
     public function index()
     {
-        ${{crudName}} = {{modelName}}::paginate(15);
+        ${{crudName}} = {{modelName}}::paginate({{pagination}});
 
         return view('{{viewPath}}{{viewName}}.index', compact('{{crudName}}'));
     }

--- a/src/stubs/index.blade.stub
+++ b/src/stubs/index.blade.stub
@@ -31,7 +31,7 @@
                                     'class' => 'btn btn-danger btn-xs',
                                     'title' => 'Delete %%modelName%%',
                                     'onclick'=>'return confirm("Confirm delete?")'
-                            ));!!}
+                            )) !!}
                         {!! Form::close() !!}
                     </td>
                 </tr>

--- a/src/stubs/model.stub
+++ b/src/stubs/model.stub
@@ -21,4 +21,6 @@ class DummyClass extends Model
      * @var array
      */
     protected $fillable = {{fillable}};
+
+    {{relationships}}
 }

--- a/src/stubs/show.blade.stub
+++ b/src/stubs/show.blade.stub
@@ -15,7 +15,7 @@
                     'class' => 'btn btn-danger btn-xs',
                     'title' => 'Delete %%modelName%%',
                     'onclick'=>'return confirm("Confirm delete?")'
-            ));!!}
+            )) !!}
         {!! Form::close() !!}
     </h1>
     <div class="table-responsive">


### PR DESCRIPTION
- Added `--pagination` option to the crud:generate and crud:controller options to change amount of models shown per page on index page, e.g. `crud:generate --fields="...." --pagination=50`

-  added `--indexes` option (see #102)
e.g. `crud:generate --fields="title#string,some_value#integer" --indexes="some_value"` which will result in a migration of `$table->index('some_value');`. You can also do `--indexes="some_value#unique"` which will result in `$table->unique('some_value');`.

- added `--required-fields` option to allow for required fields to be specified (this means it's now ignoring any #req or #required that may be defined in the fields string. This helps make the crud definition easier to write and understand. e.g. `crud:generate --fields="title#string,value#integer" --required-fields="title"`. Fields that are not required will be set to `nullable`

- added `--foreign-keys` option to migration and generate command. This will create references in the migration table only, and won't create any relationship functions in the model class - that will come next! e.g. `--foreign-keys="owner_id#id#owners"` where owner_id is the field name of the current table, id is the id column name on the related table, and owners is the related table name.

- added `--relationships` option to auto-create relationship methods. This will create the necessary functions in the model class for relationships. Use; `--relationships="relationshipName#relationshipType#argsSeparatedByPipes"` where relationshipType is hasOne, belongsTo etc. User is responsible for ensuring the relationship is valid. The args will be split by pipe, and fed into the function. e.g. `--relationships="owner#hasOne#App\Owner"` This will create the function `owner(){$this->hasOne('App\Owner');}`. Notice that for each arg in the third section, single quotes will be wrapped around the string.

- in crud:generate, changed `--namespace` argument to `--controller-namespace` and also added a `--model-namespace` argument for model namespaces

- updated readme.md

- pagination now uses 25 as the default instead of 15

- few typos