### PR TITLE
Readme file changed to make it more helpful for beginners

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
     PHP >= 5.5.9
 
 ## Installation
+Open your terminal(CLI), go to the root directory of your Laravel project, then follow the following procedure. 
 
 1. Run
     ```
@@ -26,7 +27,7 @@
         }
     }
     ```
-3. Install **laravelcollective/html** helper package.
+3. Install **laravelcollective/html** helper package if you haven't installed it already.
     * Run
 
     ```


### PR DESCRIPTION
It may happen that a beginner don't know where to run the command. He may just open then terminal and start to execute the command as he is a beginner and he isn't used with CLI yet. He may don't know how Laravel package works, how he can use them. So, its required to told him that he need to go to the root directory of his project. 
Another change is, Many of Laravel user may have been using Collective already in their project so he don't need to worry about the collective installation process. It is specified.