### PR TITLE
Unreachable break removed from switch

### DIFF
--- a/src/Commands/CrudViewCommand.php
+++ b/src/Commands/CrudViewCommand.php
@@ -432,18 +432,14 @@ class CrudViewCommand extends Command
         switch ($this->typeLookup[$item['type']]) {
             case 'password':
                 return $this->createPasswordField($item);
-                break;
             case 'datetime-local':
             case 'time':
                 return $this->createInputField($item);
-                break;
             case 'radio':
                 return $this->createRadioField($item);
-                break;
             case 'select':
             case 'enum':
                 return $this->createSelectField($item);
-                break;
             default: // text
                 return $this->createFormField($item);
         }


### PR DESCRIPTION
As the return statement already returning back from the function then no need of break statement after return. break statement is unreachable.