### PR TITLE
Absolute path is not very convenient to use

### DIFF
--- a/src/Commands/CrudCommand.php
+++ b/src/Commands/CrudCommand.php
@@ -161,7 +161,7 @@ class CrudCommand extends Command
      */
     protected function processJSONFields($file)
     {
-        $json = File::get($file);
+        $json = File::get(base_path($file));
         $fields = json_decode($json);
 
         $fieldsString = '';


### PR DESCRIPTION
You can just put a file, example `database/migrations/data/posts.json`
And this will not cause any problems when regenerating