### PR TITLE
Use row number instead of ID

### DIFF
--- a/src/stubs/index.blade.stub
+++ b/src/stubs/index.blade.stub
@@ -30,13 +30,13 @@
                             <table class="table table-borderless">
                                 <thead>
                                     <tr>
-                                        <th>ID</th>%%formHeadingHtml%%<th>Actions</th>
+                                        <th>#</th>%%formHeadingHtml%%<th>Actions</th>
                                     </tr>
                                 </thead>
                                 <tbody>
                                 @foreach($%%crudName%% as $item)
                                     <tr>
-                                        <td>{{ $item->id }}</td>
+                                        <td>{{ $loop->iteration }}</td>
                                         %%formBodyHtml%%
                                         <td>
                                             <a href="{{ url('/%%routeGroup%%%%viewName%%/' . $item->%%primaryKey%%) }}" title="View %%modelName%%"><button class="btn btn-info btn-xs"><i class="fa fa-eye" aria-hidden="true"></i> View</button></a>


### PR DESCRIPTION
Since ID is kind of a private field, it would be better if the row number is displayed on the item list instead of the ID