### PR TITLE
fixed error when trying to create crud from json file php7

### DIFF
--- a/src/Commands/CrudCommand.php
+++ b/src/Commands/CrudCommand.php
@@ -178,7 +178,7 @@ class CrudCommand extends Command
         $fieldsString = '';
         foreach ($fields->fields as $field) {
             if ($field->type == 'select') {
-                $fieldsString .= $field->name . '#' . $field->type . '#options=' . implode(',', $field->options) . ';';
+                $fieldsString .= $field->name . '#' . $field->type . '#options=' . implode(',', (array) $field->options) . ';';
             } else {
                 $fieldsString .= $field->name . '#' . $field->type . ';';
             }


### PR DESCRIPTION
fixed error 'implode(): Invalid arguments passed' on create crud from json file.