### PR TITLE
Fixed file upload snippet to not treat file input like an array

### DIFF
--- a/src/Commands/CrudControllerCommand.php
+++ b/src/Commands/CrudControllerCommand.php
@@ -123,15 +123,8 @@ class CrudControllerCommand extends GeneratorCommand
 
         $snippet = <<<EOD
         if (\$request->hasFile('{{fieldName}}')) {
-            foreach(\$request['{{fieldName}}'] as \$file){
-                \$uploadPath = public_path('/uploads/{{fieldName}}');
-
-                \$extension = \$file->getClientOriginalExtension();
-                \$fileName = rand(11111, 99999) . '.' . \$extension;
-
-                \$file->move(\$uploadPath, \$fileName);
-                \$requestData['{{fieldName}}'] = \$fileName;
-            }
+            \$request['{{fieldName}}']->store('/uploads/{{fieldName}}', 'public');
+            \$requestData['{{fieldName}}'] = \$request['{{fieldName}}']->hashName();
         }
 EOD;
 


### PR DESCRIPTION
The current views generated for file inputs don't facilitate arrays of file uploads, and so the handling of the file data can be greatly simplified (currently, when its treated as an array, its not working at all).

Secondly, updated to use Laravel's built in `store` method as well as the built in `hashName()` method - this will make it far more consistent with how other files are uploaded

Future enhancements would include the migrations for files creating multiple fields (original file name, path, mimetype, etc).