### PR TITLE
Added file field stub to account for existing files

### DIFF
--- a/src/Commands/CrudViewCommand.php
+++ b/src/Commands/CrudViewCommand.php
@@ -473,6 +473,8 @@ class CrudViewCommand extends Command
             case 'select':
             case 'enum':
                 return $this->createSelectField($item);
+            case 'file':
+                return $this->createFileField($item);
             default: // text
                 return $this->createFormField($item);
         }
@@ -616,6 +618,31 @@ class CrudViewCommand extends Command
         $markup = File::get($this->viewDirectoryPath . 'form-fields/select-field.blade.stub');
         $markup = str_replace($start . 'required' . $end, $required, $markup);
         $markup = str_replace($start . 'options' . $end, $item['options'], $markup);
+        $markup = str_replace($start . 'itemName' . $end, $item['name'], $markup);
+        $markup = str_replace($start . 'crudNameSingular' . $end, $this->crudNameSingular, $markup);
+
+        return $this->wrapField(
+            $item,
+            $markup
+        );
+    }
+
+    /**
+     * Create a file field using the form helper.
+     *
+     * @param  array $item
+     *
+     * @return string
+     */
+    protected function createFileField($item)
+    {
+        $start = $this->delimiter[0];
+        $end = $this->delimiter[1];
+
+        $required = $item['required'] ? 'required' : '';
+
+        $markup = File::get($this->viewDirectoryPath . 'form-fields/file-field.blade.stub');
+        $markup = str_replace($start . 'required' . $end, $required, $markup);
         $markup = str_replace($start . 'itemName' . $end, $item['name'], $markup);
         $markup = str_replace($start . 'crudNameSingular' . $end, $this->crudNameSingular, $markup);
 

--- a/src/stubs/views/html/form-fields/file-field.blade.stub
+++ b/src/stubs/views/html/form-fields/file-field.blade.stub
@@ -1,0 +1,4 @@
+@if(isset($%%crudNameSingular%%->%%itemName%%))
+    <a href="{{ Storage::url('uploads/%%itemName%%/' . $%%crudNameSingular%%->%%itemName%%) }}">Existing %%itemName%%</a>
+@endif
+<input class="form-control" name="%%itemName%%" type="file" id="%%itemName%%" %%required%% />

--- a/src/stubs/views/laravelcollective/form-fields/file-field.blade.php
+++ b/src/stubs/views/laravelcollective/form-fields/file-field.blade.php
@@ -1,0 +1,5 @@
+@if(isset($%%crudNameSingular%%->%%itemName%%))
+    <a href="{{ Storage::url('uploads/%%itemName%%/' . $%%crudNameSingular%%->%%itemName%%) }}">Existing %%itemName%%</a>
+@endif
+<input class="form-control" name="%%itemName%%" type="file" id="%%itemName%%" %%required%% />
+{!! Form::file('%%itemName%%', null, ('%%required%%' == 'required') ? ['class' => 'form-control', 'required' => 'required'] : ['class' => 'form-control']) !!}


### PR DESCRIPTION
The current default form-field.blade.php does not correctly address files. Input type file cannot accept a value, and such the existing file needs to be displayed separately.