### PR TITLE
Fixed the generation of the show view contents to show all fields

### DIFF
--- a/src/Commands/CrudViewCommand.php
+++ b/src/Commands/CrudViewCommand.php
@@ -332,18 +332,19 @@ class CrudViewCommand extends Command
 
         $i = 0;
         foreach ($this->formFields as $key => $value) {
-            if ($i == $this->defaultColumnsToShow) {
-                break;
-            }
-
             $field = $value['name'];
             $label = ucwords(str_replace('_', ' ', $field));
             if ($this->option('localize') == 'yes') {
                 $label = '{{ trans(\'' . $this->crudName . '.' . $field . '\') }}';
             }
+            $this->formBodyHtmlForShowView .= '<tr><th> ' . $label . ' </th><td> {{ $%%crudNameSingular%%->' . $field . ' }} </td></tr>';
+
+            if ($i >= $this->defaultColumnsToShow) {
+                continue;
+            }
+
             $this->formHeadingHtml .= '<th>' . $label . '</th>';
             $this->formBodyHtml .= '<td>{{ $item->' . $field . ' }}</td>';
-            $this->formBodyHtmlForShowView .= '<tr><th> ' . $label . ' </th><td> {{ $%%crudNameSingular%%->' . $field . ' }} </td></tr>';
 
             $i++;
         }


### PR DESCRIPTION
Currently both the index and show blades use the same logic for which fields to show. While it makes sense to limit the index view to say columns, for the show view where the fields are stacked vertically, this is no longer an issue and should show everything.

The chances basically shuffle around the order - everything above the defaultColumnsToShow check are executed for every field (and so the show view will get all fields). 