### PR TITLE
Order by created at when indexing the models

### DIFF
--- a/src/stubs/controller.stub
+++ b/src/stubs/controller.stub
@@ -21,9 +21,9 @@ class DummyClass extends Controller
         $perPage = {{pagination}};
 
         if (!empty($keyword)) {
-            ${{crudName}} = {{modelName}}::{{whereSnippet}}paginate($perPage);
+            ${{crudName}} = {{modelName}}::{{whereSnippet}}orderBy('created_at', 'desc')->paginate($perPage);
         } else {
-            ${{crudName}} = {{modelName}}::paginate($perPage);
+            ${{crudName}} = {{modelName}}::orderBy('created_at', 'desc')->paginate($perPage);
         }
 
         return view('{{viewPath}}{{viewName}}.index', compact('{{crudName}}'));


### PR DESCRIPTION
I think this is more practical than just outputting them. Especially when not using linear inserts into DB.