### PR TITLE
Fix path when using custom_template

### DIFF
--- a/src/Commands/CrudControllerCommand.php
+++ b/src/Commands/CrudControllerCommand.php
@@ -46,7 +46,7 @@ class CrudControllerCommand extends GeneratorCommand
     protected function getStub()
     {
         return config('crudgenerator.custom_template')
-        ? config('crudgenerator.path') . '/controller.stub'
+        ? config('crudgenerator.path') . 'controller.stub'
         : __DIR__ . '/../stubs/controller.stub';
     }
 

--- a/src/Commands/CrudMigrationCommand.php
+++ b/src/Commands/CrudMigrationCommand.php
@@ -71,7 +71,7 @@ class CrudMigrationCommand extends GeneratorCommand
     protected function getStub()
     {
         return config('crudgenerator.custom_template')
-        ? config('crudgenerator.path') . '/migration.stub'
+        ? config('crudgenerator.path') . 'migration.stub'
         : __DIR__ . '/../stubs/migration.stub';
     }
 

--- a/src/Commands/CrudModelCommand.php
+++ b/src/Commands/CrudModelCommand.php
@@ -41,7 +41,7 @@ class CrudModelCommand extends GeneratorCommand
     protected function getStub()
     {
         return config('crudgenerator.custom_template')
-        ? config('crudgenerator.path') . '/model.stub'
+        ? config('crudgenerator.path') . 'model.stub'
         : __DIR__ . '/../stubs/model.stub';
     }
 


### PR DESCRIPTION
When using a custom template path the method has a double slash in the full path to the stub.