### PR TITLE
Laravel 6 RFC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 composer.lock
 .DS_Store
+/.idea

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6.4",
+        "php": "^7.2",
         "illuminate/support": "^6.0",
         "laravelcollective/html": "^6.0",
         "laravel/helpers": "^1.1"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require-dev": {
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^8.0",
-        "orchestra/testbench": "^3.0"
+        "orchestra/testbench": "^3.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,15 @@
         }
     ],
     "require": {
-        "php": ">=5.6.4|>=7.0",
-        "illuminate/support": "^5.3|^6.0",
-        "laravelcollective/html": "^5.3|^6.0"
+        "php": ">=5.6.4",
+        "illuminate/support": "^6.0",
+        "laravelcollective/html": "^6.0",
+        "laravel/helpers": "^1.1"
     },
     "require-dev": {
-        "mockery/mockery": "^0.9.6",
-        "phpunit/phpunit": "^5.7",
-        "orchestra/testbench": "^3.3"
+        "mockery/mockery": "^1.0",
+        "phpunit/phpunit": "^8.0",
+        "orchestra/testbench": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/CrudGeneratorTest.php
+++ b/tests/CrudGeneratorTest.php
@@ -17,9 +17,7 @@ class CrudGeneratorTest extends TestCase
             'name' => 'CustomersController',
             '--crud-name' => 'customers',
             '--model-name' => 'Customer',
-        ]);
-
-        $this->assertContains('Controller created successfully.', $this->consoleOutput());
+        ])->expectsOutput('Controller created successfully.');
 
         $this->assertFileExists(app_path('Http/Controllers') . '/CustomersController.php');
     }
@@ -29,9 +27,7 @@ class CrudGeneratorTest extends TestCase
         $this->artisan('crud:model', [
             'name' => 'Customer',
             '--fillable' => "['name', 'email']",
-        ]);
-
-        $this->assertContains('Model created successfully.', $this->consoleOutput());
+        ])->expectsOutput('Model created successfully.');
 
         $this->assertFileExists(app_path() . '/Customer.php');
     }
@@ -41,9 +37,7 @@ class CrudGeneratorTest extends TestCase
         $this->artisan('crud:migration', [
             'name' => 'customers',
             '--schema' => 'name#string; email#email',
-        ]);
-
-        $this->assertContains('Migration created successfully.', $this->consoleOutput());
+        ])->expectsOutput('Migration created successfully.');
     }
 
     public function testViewGenerateCommand()
@@ -51,9 +45,7 @@ class CrudGeneratorTest extends TestCase
         $this->artisan('crud:view', [
             'name' => 'customers',
             '--fields' => "title#string; body#text",
-        ]);
-
-        $this->assertContains('View created successfully.', $this->consoleOutput());
+        ])->expectsOutput('View created successfully.');
 
         $this->assertDirectoryExists(config('view.paths')[0] . '/customers');
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,8 +1,6 @@
 <?php
 abstract class TestCase extends Orchestra\Testbench\TestCase
 {
-    protected $consoleOutput;
-
     protected function getPackageProviders($app)
     {
         return [\Appzcoder\CrudGenerator\CrudGeneratorServiceProvider::class];
@@ -26,20 +24,13 @@ abstract class TestCase extends Orchestra\Testbench\TestCase
         ]);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         exec('rm -rf ' . __DIR__ . '/temp/*');
         exec('rm -rf ' . app_path() . '/*');
         exec('rm -rf ' . database_path('migrations') . '/*');
-    }
-
-    public function tearDown()
-    {
-        parent::tearDown();
-
-        $this->consoleOutput = '';
     }
 
     public function resolveApplicationConsoleKernel($app)
@@ -49,10 +40,5 @@ abstract class TestCase extends Orchestra\Testbench\TestCase
         });
 
         $app->singleton('Illuminate\Contracts\Console\Kernel', Kernel::class);
-    }
-
-    public function consoleOutput()
-    {
-        return $this->consoleOutput ?: $this->consoleOutput = $this->app[Kernel::class]->output();
     }
 }


### PR DESCRIPTION
## Work Done
* Added `.idea` dir to gitignore for jetbrains users.
* Upgraded composer file to support Laravel 6 dependencies.
    * Added the `laravel/helpers` package to suppport functions like `str_singular`.
* Added return type to `TestCase` base class `setUp` function.
* Revised tests to expect command output the newest way detailed in [Laravel's docs](https://laravel.com/docs/5.8/console-tests#expecting-input-and-output)
    * Removed lines in test case base related to old command output assertion implementation.
    * Removed `teardown` as it isn't needed anymore after removing above.

Seems to get tests running again. Let me know what you think. Installed locally to a laravel 6 project and was successfully generating CRUD via the commands.